### PR TITLE
ACT test case changes

### DIFF
--- a/test/assisted.spec.ts
+++ b/test/assisted.spec.ts
@@ -1061,10 +1061,6 @@ test("bc4a75", (t) =>
       "4af645",
       "6120d9",
     ],
-    lax: [
-      // Alfa intentionally applies to elements whose role is implicit
-      "d6a643",
-    ],
   }));
 
 test("afw4f7", (t) =>

--- a/test/assisted.spec.ts
+++ b/test/assisted.spec.ts
@@ -838,7 +838,7 @@ test("d0f69e", (t) =>
     lax: [
       // Alfa does not consider ARIA tables
       // https://github.com/act-rules/act-rules.github.io/pull/1971
-      "a56128",
+      "5dcc5b",
     ],
   }));
 

--- a/test/automated.spec.ts
+++ b/test/automated.spec.ts
@@ -313,10 +313,6 @@ test("bc4a75", (t) =>
       "4af645",
       "6120d9",
     ],
-    lax: [
-      // Alfa intentionally applies to elements whose role is implicit
-      "d6a643",
-    ],
   }));
 
 test("afw4f7", (t) =>

--- a/test/automated.spec.ts
+++ b/test/automated.spec.ts
@@ -226,7 +226,7 @@ test("d0f69e", (t) =>
     lax: [
       // Alfa does not consider ARIA tables
       // https://github.com/act-rules/act-rules.github.io/pull/1971
-      "a56128",
+      "5dcc5b",
     ],
   }));
 


### PR DESCRIPTION
ACT has replaced a test case and changed the expected outcome of another (from inapplicable to passed) so that it now matches what Alfa already did intentionally.

This was causing the weekly job that runs the tests and updates the implementation reports to fail.

This PR just updates the tests to reflect these changes. There was no need to fix anything in Alfa as the tests failing was not caused by a regression in Alfa and we didn't need to change anything in Alfa to match ACT (they changed to match Alfa 😄).

I haven't looked into why these things changed, I can just see that they did.